### PR TITLE
Minor fixes on the main site

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ meetup-group:
 
 ## Welcome
 
-Welcome to _OWASP Stuttgart Chapter_, a regional city chapter within [OWASP Germany](https://owasp.org/www-chapter-germany/). Our Chapter serves southern Germany particular within the Swabia region as a platform to discuss and share topics all around information and application security.
+Welcome to _OWASP Stuttgart Chapter_. Our Chapter serves southern Germany particular within the Swabia region as a platform to discuss and share topics all around information and application security.
 
 Anyone interested and enthusiastic about application security is welcome. All meetings are free and open. **You do not have to be an OWASP member**.
 

--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ Referrals to this website or to individual meetings to colleagues or acquaintanc
 
 ## Upcoming Events
 
-Check out our [Upcoming Events](https://www.meetup.com/de-DE/OWASP-Stuttgart/events/)
+Check out our [Upcoming Events](https://www.meetup.com/owasp-stuttgart-chapter/events/)
 
 ## Information about Stuttgart Chapter Events
 


### PR DESCRIPTION
Removes part about stuttgart chapter being a regional chapter within OWASP Germany as requested.
Uses correct url of meetup events page.